### PR TITLE
Fix typos in footer height reduction notes

### DIFF
--- a/footer-height-reduction.md
+++ b/footer-height-reduction.md
@@ -2,7 +2,7 @@
 
 ## Changes Made
 
-The footer component has been modified to address the issue: "esta muy alto, podemoms omitir los enlases ya tenemos el menu" (it's too tall, we can omit the links since we already have the menu).
+The footer component has been modified to address the issue: "esta muy alto, podemos omitir los enlaces ya tenemos el menu" (it's too tall, we can omit the links since we already have the menu).
 
 ### Removed Elements
 - Removed the navigation links section (`footer-links` div) since these links are already present in the Header menu


### PR DESCRIPTION
## Summary
- Correct spelling errors in footer height reduction documentation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d62b52448832486557cd0c478af77