### PR TITLE
fix: remove stray text in reverse gradient animation

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -86,7 +86,7 @@ body {
   }
   50% {
     background-position: 0% 50%;
-  }main
+  }
   100% {
     background-position: 100% 50%;
   }


### PR DESCRIPTION
## Summary
- remove extraneous `main` after 50% block in `@keyframes gradient-animation-reverse`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d62b95dbc832481add0c6e394638b