### PR TITLE
feat: add responsive mobile styles

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -93,7 +93,6 @@ body {
       background-position: 100% 50%;
     }
   }
-}
 
 
 .animated-background-reverse {
@@ -144,4 +143,20 @@ footer {
   transition: opacity 0.5s ease; /* Transición suave para la opacidad */
   backdrop-filter: blur(10px);
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+}
+
+/* Ajustes responsivos globales para pantallas pequeñas */
+@media (max-width: 600px) {
+  main {
+    padding-top: 80px;
+    padding-bottom: 80px;
+  }
+
+  section {
+    padding: 1.5rem 1rem;
+  }
+
+  .rexdevelop-text {
+    font-size: 1.5rem;
+  }
 }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -231,6 +231,21 @@ onBeforeUnmount(() => {
 }
 
 /* Responsive behavior */
+@media (max-width: 600px) {
+  .main-header {
+    padding: 0.5rem 1rem;
+  }
+
+  .avatar {
+    width: 40px;
+    height: 40px;
+  }
+
+  .rexdevelop-text {
+    font-size: 1.5rem;
+  }
+}
+
 @media (max-width: 900px) {
   .nav-list { display: none; }
   .menu-toggle { display: block; }


### PR DESCRIPTION
## Summary
- add global mobile padding and text sizing
- shrink header elements on small screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d6c818ae48324bb05ebb8a350ff30